### PR TITLE
BAU: only attempt to use sharepoint config at call time

### DIFF
--- a/src/common/connectors/sharepoint/sharepoint.js
+++ b/src/common/connectors/sharepoint/sharepoint.js
@@ -3,16 +3,6 @@ import { Client } from '@microsoft/microsoft-graph-client'
 import { TokenCredentialAuthenticationProvider } from '@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials/index.js'
 import { config } from '../../../config.js'
 
-const { tenantId, clientId, clientSecret } = config.get('sharepoint')
-
-const credential = new ClientSecretCredential(tenantId, clientId, clientSecret)
-
-const authProvider = new TokenCredentialAuthenticationProvider(credential, {
-  scopes: ['https://graph.microsoft.com/.default']
-})
-
-const graphClient = Client.initWithMiddleware({ authProvider })
-
 /**
  * @param {string} reference
  * @param {string} fileName
@@ -20,8 +10,20 @@ const graphClient = Client.initWithMiddleware({ authProvider })
  * @returns {Promise<object>}
  */
 export async function uploadFile(reference, fileName, file) {
-  const { driveId, folderPath } = config.get('sharepoint')
+  const { tenantId, clientId, clientSecret, driveId, folderPath } =
+    config.get('sharepoint')
 
+  const credential = new ClientSecretCredential(
+    tenantId,
+    clientId,
+    clientSecret
+  )
+
+  const authProvider = new TokenCredentialAuthenticationProvider(credential, {
+    scopes: ['https://graph.microsoft.com/.default']
+  })
+
+  const graphClient = Client.initWithMiddleware({ authProvider })
   return graphClient
     .api(
       `/drives/${driveId}/items/root:/${folderPath}/${reference}/${fileName}:/content`


### PR DESCRIPTION
This is not mandatory in all environments, but without the sharepoint config we cannot release the service.

This makes the path to prod a little trickier, in a way that we can avoid by reading the config only when we're sure sharepoint is going to be used.